### PR TITLE
[fix/122-getGroupProfile] 그룹 멤버 이미지 조회 시 관리자가 중복되는 문제를 수정하고 관리자가 가장 앞에 담기도록 구현

### DIFF
--- a/src/main/java/com/lesso/neverland/group/application/GroupService.java
+++ b/src/main/java/com/lesso/neverland/group/application/GroupService.java
@@ -112,12 +112,13 @@ public class GroupService {
 
         List<String> memberImages = group.getUserTeams().stream()
                 .filter(userTeam -> "active".equals(userTeam.getStatus()))
+                .filter(userTeam -> !userTeam.getUser().equals(group.getAdmin()))
                 .map(userTeam -> userTeam.getUser().getProfile().getProfileImage())
-                .limit(2).toList();
+                .limit(2)
+                .toList();
         imageList.addAll(memberImages);
         return imageList;
     }
-
 
     // [관리자] 그룹 수정 화면 조회
     public BaseResponse<GroupEditViewResponse> getGroupEditView(Long groupIdx) {


### PR DESCRIPTION
## 📌 이슈 번호
#122

## 📢 의논 사항