### PR TITLE
[fix/87-createPuzzle] 퍼즐 생성 시 이미지가 없어도 요청이 가능하도록 수정

### DIFF
--- a/src/main/java/com/lesso/neverland/puzzle/application/PuzzleService.java
+++ b/src/main/java/com/lesso/neverland/puzzle/application/PuzzleService.java
@@ -146,7 +146,7 @@ public class PuzzleService {
 
         LocalDate puzzleDate = convertToLocalDate(createPuzzleRequest.puzzleDate());
         Puzzle newPuzzle = createPuzzle(createPuzzleRequest, group, writer, puzzleDate);
-        if (!image.isEmpty()) {
+        if (image != null && !image.isEmpty()) {
             String imagePath = imageService.uploadImage("puzzle", image);
             newPuzzle.addPuzzleImage(imagePath);
         }


### PR DESCRIPTION
## 📌 이슈 번호
#87

## 📢 의논 사항